### PR TITLE
Add coverage metrics via istanbul

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 build/
+coverage/
 ext/
 node_modules/
 packages/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ packages/
 classic.json
 sass/example/bootstrap.json
 sass/example/bootstrap.js
+
+# Coverage
+.instrumented/
+test/.index_coverage.html
+coverage/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
   "author": "terrestris GmbH & Co. KG",
   "scripts": {
     "js-lint": "eslint -c .eslintrc ./",
-    "test": "mocha-phantomjs --ssl-protocol=any --ignore-ssl-errors=true test/index.html"
+    "test": "mocha-phantomjs --ssl-protocol=any --ignore-ssl-errors=true test/index.html",
+    "coverage-clean": "rm -rf .instrumented/ && rm -rf ./coverage/ && rm -f ./test/.index_coverage.html",
+    "coverage-sed": "sed -e 's/..\\/app/..\\/.instrumented\\/app/g' ./test/index.html > ./test/.index_coverage.html",
+    "coverage-instrument": "istanbul instrument -o .instrumented/ -x '**/ext/** **/build/** **/node_modules/** **/packages/** **/sass/** **/test/**' ./",
+    "coverage-report": "mocha-phantomjs --ssl-protocol=any --ignore-ssl-errors=true --hooks ./test/phantom_hooks.js ./test/.index_coverage.html && istanbul report --root ./coverage html",
+    "coverage-run": "npm run coverage-clean && npm run coverage-sed && npm run coverage-instrument && npm run coverage-report"
   },
   "repository": {
     "type": "git",
@@ -20,6 +25,7 @@
   "dependencies": {
     "eslint": "1.7.3",
     "expect.js": "0.3.1",
+    "istanbul": "0.4.0",
     "mocha": "2.3.3",
     "mocha-phantomjs": "4.0.1",
     "sinon": "1.17.2"

--- a/test/phantom_hooks.js
+++ b/test/phantom_hooks.js
@@ -1,0 +1,16 @@
+/*eslint no-console: 0*/
+module.exports = {
+    afterEnd : function(runner) {
+        var fs = require('fs');
+        var coverage = runner.page.evaluate(function() {
+            return window.__coverage__;
+        });
+
+        if (coverage) {
+            console.log('Writing coverage to coverage/coverage.json');
+            fs.write('coverage/coverage.json', JSON.stringify(coverage), 'w');
+        } else {
+            console.log('No coverage data generated');
+        }
+    }
+};


### PR DESCRIPTION
This PR provides an opportunity for calculating global test coverage metrics by the use of [istanbul](https://www.npmjs.com/package/istanbul). To calculate this metrics simply run `npm run coverage-run` and visit `<CLIENT-PATH>/coverage/index.html` in your browser.  