### PR TITLE
Add missing installation step to README (Fixes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 
   `git remote add upstream https://github.com/terrestris/shogun2-client.git`
 
+* Run `sencha package repo add BasiGX http://terrestris.github.io/BasiGX/cmd/pkgs`
+
 * Run `sencha app upgrade /path/to/extjs`
 
 * Run `sencha app refresh`


### PR DESCRIPTION
Add missing call to add BasiGX as known repository for the sencha app in the ``Installation`` section of the README.