### PR TITLE
Correct URL path template to load application context

### DIFF
--- a/app/util/ApplicationContext.js
+++ b/app/util/ApplicationContext.js
@@ -19,7 +19,7 @@ Ext.define('ShogunClient.util.ApplicationContext', {
          * The path configs needed by this class.
          */
         pathConfig: {
-            appContextUrlTpl: '../application/get.action?id={0}'
+            appContextUrlTpl: '../rest/applications/{0}/'
         },
 
         /**


### PR DESCRIPTION
This corrects the URL template used to load the application context for a certain application. Now the REST interface is used instead of the ``get.action`` method, which has been removed in SHOGun2 (fixes #11)