### PR TITLE
Use layerStyles property in OL source creation

### DIFF
--- a/app/view/component/MapController.js
+++ b/app/view/component/MapController.js
@@ -157,7 +157,8 @@ Ext.define('ShogunClient.view.component.MapController', {
             params: {
                 'LAYERS': mapLayerSource.layerNames,
                 'VERSION': mapLayerSource.version,
-                'TILED': true
+                'TILED': true,
+                'STYLES': mapLayerSource.layerStyles || null
             },
             crossOrigin: mapLayerSource.crossOrigin || null,
             gutter: mapLayerSource.gutter || 0,


### PR DESCRIPTION
This applies the 'layerStyles' property of the TileWMSDataSourceTemplate to the 'STYLES' property in the params object of the OL source. So it will be possible to query a different style, e. g. for a WMS layer.